### PR TITLE
Streamline steps to a single run.sh for quicker test

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-docker run --name mysql-langchain-container \
-  -v $(pwd)/data:/var/lib/mysql \
-  -e MYSQL_ROOT_PASSWORD=password \
-  -e MYSQL_DATABASE=sample_db \
-  -p 3306:3306 \
-  -d mysql:latest

--- a/export_key.sh
+++ b/export_key.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-export OPENAI_API_KEY=<your key>

--- a/readme.md
+++ b/readme.md
@@ -4,17 +4,9 @@ The purpose of this repo is to get a mysql database up and running in docker and
 Fortunately, langchain makes this very simple. 
 
 
-## Requirements
-OPENAI_API_KEY must be updated in export_key.sh
-
+## Usage
 ```
-pip install -r requirements.txt     # install required packages
+chmod +x run.sh                    #make executable
 
-source export_key.sh                # export OPENAI_API_KEY
-
-sh docker-build.sh                  # spin up mysql docker container
-
-python setup_mysql.py               # setup mysql database and Sales table
-
-python process.py                   # run some langchain queries
+run.sh <open_api_key>              #setup python env, a mysql instance, run a langchain docker container, and run some queries
 ```

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+export OPENAI_API_KEY=$1
+
+if [ -z "$OPENAI_API_KEY" ]
+then
+      echo "\OPENAI_API_KEY cannot be empty, usage: run.sh <openai api key>"
+else
+    if [ -d "venv" ] 
+    then
+        source venv/bin/activate
+    else
+        python -m venv venv
+        source venv/bin/activate 
+        pip install -r requirements.txt
+    fi 
+
+    python setup_mysql.py
+
+    docker run --name mysql-langchain-container \
+        -v $(pwd)/data:/var/lib/mysql \
+        -e MYSQL_ROOT_PASSWORD=password \
+        -e MYSQL_DATABASE=sample_db \
+        -p 3306:3306 \
+        -d mysql:latest
+    
+    python process.py
+
+fi
+


### PR DESCRIPTION
Just consolidating everything to a single shell script to make it quicker for someone (aka me) to use this example. 

Ideally, you could build a docker container using the lang chain container and do everything in there, but I get then it may be more difficult to get the queries out. 